### PR TITLE
Fix notice, displayed if repeater field created before plugin installed

### DIFF
--- a/acf-repeater-tabs.php
+++ b/acf-repeater-tabs.php
@@ -61,8 +61,10 @@ add_filter('acf/render_field/type=repeater', 'jpn_acf_tabs_render_pre', 9, 1);
 function jpn_acf_tabs_render_pre( $field ) {
 	
 	// bail early if no 'admin_only' setting
-	if( $field['jpn-tabs'] == 'horizontal' || $field['jpn-tabs'] == 'vertical' ) {
-        echo '<br><div class="jpn-tabs-activated jpn-'.$field['jpn-tabs'].'">';
+    if( array_key_exists( 'jpn-tabs', $field ) ) {
+        if( $field['jpn-tabs'] == 'horizontal' || $field['jpn-tabs'] == 'vertical' ) {
+            echo '<br><div class="jpn-tabs-activated jpn-'.$field['jpn-tabs'].'">';
+        }
     }
 	
 }


### PR DESCRIPTION
Steps to reproduce issue:

1. Install clear WordPress and ACF
2. Create field with type "Repeater"
3. Install acf-repeater-tabs
4. Get notice in dashboard

